### PR TITLE
Allow iam client id/secret to be configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /tmp/
 .DS_Store
 test/html_reports/
+.project
 
 # Used by dotenv library to load environment variables.
 .env

--- a/lib/ibm_cloud_sdk_core/base_service.rb
+++ b/lib/ibm_cloud_sdk_core/base_service.rb
@@ -28,6 +28,8 @@ module IBMCloudSdkCore
         iam_apikey: nil,
         iam_access_token: nil,
         iam_url: nil,
+        iam_client_id: nil,
+        iam_client_secret: nil,
         display_name: nil
       }
       vars = defaults.merge(vars)
@@ -42,7 +44,9 @@ module IBMCloudSdkCore
       @display_name = vars[:display_name]
 
       if (!vars[:iam_access_token].nil? || !vars[:iam_apikey].nil?) && !@icp_prefix
-        set_token_manager(iam_apikey: vars[:iam_apikey], iam_access_token: vars[:iam_access_token], iam_url: vars[:iam_url])
+        set_token_manager(iam_apikey: vars[:iam_apikey], iam_access_token: vars[:iam_access_token],
+                          iam_url: vars[:iam_url], iam_client_id: vars[:iam_client_id],
+                          iam_client_secret: vars[:iam_client_secret])
       elsif !vars[:iam_apikey].nil? && @icp_prefix
         @username = "apikey"
         @password = vars[:iam_apikey]
@@ -244,11 +248,16 @@ module IBMCloudSdkCore
       return str.start_with?("{", "\"") || str.end_with?("}", "\"") unless str.nil?
     end
 
-    def set_token_manager(iam_apikey: nil, iam_access_token: nil, iam_url: nil)
+    def set_token_manager(iam_apikey: nil, iam_access_token: nil, iam_url: nil,
+                          iam_client_id: nil, iam_client_secret: nil)
       @iam_apikey = iam_apikey
       @iam_access_token = iam_access_token
       @iam_url = iam_url
-      @token_manager = IAMTokenManager.new(iam_apikey: iam_apikey, iam_access_token: iam_access_token, iam_url: iam_url)
+      @iam_client_id = iam_client_id
+      @iam_client_secret = iam_client_secret
+      @token_manager =
+        IAMTokenManager.new(iam_apikey: iam_apikey, iam_access_token: iam_access_token,
+                            iam_url: iam_url, iam_client_id: iam_client_id, iam_client_secret: iam_client_secret)
     end
 
     def add_timeout(timeout)

--- a/lib/ibm_cloud_sdk_core/iam_token_manager.rb
+++ b/lib/ibm_cloud_sdk_core/iam_token_manager.rb
@@ -8,16 +8,19 @@ require_relative("./version.rb")
 module IBMCloudSdkCore
   # Class to manage IAM Token Authentication
   class IAMTokenManager
-    DEFAULT_IAM_URL = "https://iam.bluemix.net/identity/token"
+    DEFAULT_IAM_URL = "https://iam.cloud.ibm.com/identity/token"
     CONTENT_TYPE = "application/x-www-form-urlencoded"
     ACCEPT = "application/json"
     DEFAULT_AUTHORIZATION = "Basic Yng6Yng="
+    DEFAULT_CLIENT_ID = "bx"
+    DEFAULT_CLIENT_SECRET = "bx"
     REQUEST_TOKEN_GRANT_TYPE = "urn:ibm:params:oauth:grant-type:apikey"
     REQUEST_TOKEN_RESPONSE_TYPE = "cloud_iam"
     REFRESH_TOKEN_GRANT_TYPE = "refresh_token"
 
     attr_accessor :token_info, :user_access_token
-    def initialize(iam_apikey: nil, iam_access_token: nil, iam_url: nil)
+    def initialize(iam_apikey: nil, iam_access_token: nil, iam_url: nil,
+                   iam_client_id: nil, iam_client_secret: nil)
       @iam_apikey = iam_apikey
       @user_access_token = iam_access_token
       @iam_url = iam_url.nil? ? DEFAULT_IAM_URL : iam_url
@@ -28,12 +31,22 @@ module IBMCloudSdkCore
         "expires_in" => nil,
         "expiration" => nil
       }
+      # Both the client id and secret should be provided or neither should be provided.
+      if !iam_client_id.nil? && !iam_client_secret.nil?
+        @iam_client_id = iam_client_id
+        @iam_client_secret = iam_client_secret
+      elsif iam_client_id.nil? && iam_client_secret.nil?
+        @iam_client_id = DEFAULT_CLIENT_ID
+        @iam_client_secret = DEFAULT_CLIENT_SECRET
+      else
+        raise ArgumentError.new("Only one of 'iam_client_id' or 'iam_client_secret' were specified, but both parameters should be specified together.")
+      end
     end
 
     def request(method:, url:, headers: nil, params: nil, data: nil)
       response = nil
       if headers.key?("Content-Type") && headers["Content-Type"] == CONTENT_TYPE
-        response = HTTP.request(
+        response = HTTP.basic_auth(user: @iam_client_id, pass: @iam_client_secret).request(
           method,
           url,
           body: HTTP::URI.form_encode(data),
@@ -78,7 +91,6 @@ module IBMCloudSdkCore
     def request_token
       headers = {
         "Content-Type" => CONTENT_TYPE,
-        "Authorization" => DEFAULT_AUTHORIZATION,
         "Accept" => ACCEPT
       }
       data = {
@@ -99,7 +111,6 @@ module IBMCloudSdkCore
     def refresh_token
       headers = {
         "Content-Type" => CONTENT_TYPE,
-        "Authorization" => DEFAULT_AUTHORIZATION,
         "accept" => ACCEPT
       }
       data = {

--- a/test/unit/test_base_service.rb
+++ b/test/unit/test_base_service.rb
@@ -220,7 +220,7 @@ class BaseServiceTest < Minitest::Test
     headers = {
       "Content-Type" => "application/json"
     }
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: {
           "apikey" => "xyz",
@@ -232,7 +232,7 @@ class BaseServiceTest < Minitest::Test
           "Authorization" => "Basic Yng6Yng=",
           "Connection" => "close",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net",
+          "Host" => "iam.cloud.ibm.com",
           "User-Agent" => "http.rb/4.1.1"
         }
       ).to_return(status: 200, body: token_response.to_json, headers: {})
@@ -269,7 +269,7 @@ class BaseServiceTest < Minitest::Test
     headers = {
       "Content-Type" => "application/json"
     }
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: {
           "apikey" => "xyz",
@@ -281,7 +281,7 @@ class BaseServiceTest < Minitest::Test
           "Authorization" => "Basic Yng6Yng=",
           "Connection" => "close",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net",
+          "Host" => "iam.cloud.ibm.com",
           "User-Agent" => "http.rb/4.1.1"
         }
       ).to_return(status: 200, body: token_response.to_json, headers: {})

--- a/test/unit/test_iam_token_manager.rb
+++ b/test/unit/test_iam_token_manager.rb
@@ -8,7 +8,6 @@ WebMock.disable_net_connect!(allow_localhost: true)
 # Unit tests for the IAM Token Manager
 class IAMTokenManagerTest < Minitest::Test
   def test_request_token
-    iam_url = "https://iam.bluemix.net/identity/token"
     response = {
       "access_token" => "oAeisG8yqPY7sFR_x66Z15",
       "token_type" => "Bearer",
@@ -17,19 +16,19 @@ class IAMTokenManagerTest < Minitest::Test
       "refresh_token" => "jy4gl91BQ"
     }
 
+    # Use default iam_url, client id/secret
     token_manager = IBMCloudSdkCore::IAMTokenManager.new(
       iam_apikey: "iam_apikey",
-      iam_access_token: "iam_access_token",
-      iam_url: iam_url
+      iam_access_token: "iam_access_token"
     )
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(status: 200, body: response.to_json, headers: {})
     token_response = token_manager.send(:request_token)
@@ -63,24 +62,22 @@ class IAMTokenManagerTest < Minitest::Test
   end
 
   def test_request_token_fails_catch_exception
-    iam_url = "https://iam.bluemix.net/identity/token"
     token_manager = IBMCloudSdkCore::IAMTokenManager.new(
       iam_apikey: "iam_apikey",
-      iam_access_token: "iam_access_token",
-      iam_url: iam_url
+      iam_access_token: "iam_access_token"
     )
     response = {
       "code" => "500",
       "error" => "Oh no"
     }
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(status: 401, body: response.to_json, headers: {})
     begin
@@ -91,7 +88,7 @@ class IAMTokenManagerTest < Minitest::Test
   end
 
   def test_refresh_token
-    iam_url = "https://iam.bluemix.net/identity/token"
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
     response = {
       "access_token" => "oAeisG8yqPY7sFR_x66Z15",
       "token_type" => "Bearer",
@@ -104,14 +101,14 @@ class IAMTokenManagerTest < Minitest::Test
       iam_access_token: "iam_access_token",
       iam_url: iam_url
     )
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "grant_type" => "refresh_token", "refresh_token" => "" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(status: 200, body: response.to_json, headers: {})
     token_response = token_manager.send(:refresh_token)
@@ -157,7 +154,7 @@ class IAMTokenManagerTest < Minitest::Test
   end
 
   def test_get_token
-    iam_url = "https://iam.bluemix.net/identity/token"
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
     token_manager = IBMCloudSdkCore::IAMTokenManager.new(
       iam_apikey: "iam_apikey",
       iam_url: iam_url
@@ -174,14 +171,14 @@ class IAMTokenManagerTest < Minitest::Test
       "expiration" => 1_524_167_011,
       "refresh_token" => "jy4gl91BQ"
     }
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "iam_apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(status: 200, body: response.to_json, headers: {})
     token_manager.user_access_token = ""
@@ -192,13 +189,13 @@ class IAMTokenManagerTest < Minitest::Test
     token = token_manager.token
     assert_equal("hellohello", token)
 
-    stub_request(:post, "https://iam.bluemix.net/identity/token")
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         headers: {
           "Accept" => "application/json",
           "Authorization" => "Basic Yng6Yng=",
           "Content-Type" => "application/x-www-form-urlencoded",
-          "Host" => "iam.bluemix.net"
+          "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(status: 200, body: response.to_json, headers: {})
     token_manager.token_info["expiration"] = Time.now.to_i - 4000
@@ -216,11 +213,68 @@ class IAMTokenManagerTest < Minitest::Test
     assert_equal("dummy", token)
   end
 
+  def test_client_id_only
+    assert_raises do
+      IBMCloudSdkCore::IAMTokenManager.new(
+        iam_apikey: "iam_apikey",
+        iam_access_token: "iam_access_token",
+        iam_client_id: "client_id"
+      )
+    end
+  end
+
+  def test_client_secret_only
+    assert_raises do
+      IBMCloudSdkCore::IAMTokenManager.new(
+        iam_apikey: "iam_apikey",
+        iam_access_token: "iam_access_token",
+        iam_client_secret: "client_secret"
+      )
+    end
+  end
+
+  def test_request_token_nondefault_client_id_secret
+    response = {
+      "access_token" => "oAeisG8yqPY7sFR_x66Z15",
+      "token_type" => "Bearer",
+      "expires_in" => 3600,
+      "expiration" => 1_524_167_011,
+      "refresh_token" => "jy4gl91BQ"
+    }
+
+    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
+      iam_apikey: "iam_apikey",
+      iam_client_id: "foo",
+      iam_client_secret: "bar"
+    )
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
+      .with(basic_auth: %w[foo bar]).to_return(status: 200, body: response.to_json, headers: {})
+    token_response = token_manager.send(:request_token)
+    assert_equal(response, token_response)
+  end
+
+  def test_request_token_default_client_id_secret
+    response = {
+      "access_token" => "oAeisG8yqPY7sFR_x66Z15",
+      "token_type" => "Bearer",
+      "expires_in" => 3600,
+      "expiration" => 1_524_167_011,
+      "refresh_token" => "jy4gl91BQ"
+    }
+
+    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
+      iam_apikey: "iam_apikey"
+    )
+    stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
+      .with(basic_auth: %w[bx bx]).to_return(status: 200, body: response.to_json, headers: {})
+    token_response = token_manager.send(:request_token)
+    assert_equal(response, token_response)
+  end
+
   def test_dont_leak_constants
     assert_nil(defined? DEFAULT_IAM_URL)
     assert_nil(defined? CONTENT_TYPE)
     assert_nil(defined? ACCEPT)
-    assert_nil(defined? DEFAULT_AUTHORIZATION)
     assert_nil(defined? REQUEST_TOKEN_GRANT_TYPE)
     assert_nil(defined? REQUEST_TOKEN_RESPONSE_TYPE)
     assert_nil(defined? REFRESH_TOKEN_GRANT_TYPE)


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/851

This PR allows the iam client id and secret values to be configured when instantiating the BaseService class.   These values will then be used for basic auth when invoking the iam token service to request or refresh an IAM access token.