### PR TITLE
fix(auth): look up for apikey in creds file and use tr instead of sub

### DIFF
--- a/lib/ibm_cloud_sdk_core/base_service.rb
+++ b/lib/ibm_cloud_sdk_core/base_service.rb
@@ -68,7 +68,7 @@ module IBMCloudSdkCore
       end
 
       if @display_name && !@username && !@iam_apikey
-        service_name = @display_name.sub(" ", "_").downcase
+        service_name = @display_name.tr(" ", "_").downcase
         load_from_credential_file(service_name)
         @icp_prefix = @password&.start_with?("icp-") || @iam_apikey&.start_with?("icp-") ? true : false
       end
@@ -256,7 +256,7 @@ module IBMCloudSdkCore
     def set_credential_based_on_type(service_name, key, value)
       return unless key.include?(service_name)
 
-      @iam_apikey = value if key.include?("iam_apikey")
+      @iam_apikey = value if key.include?("iam_apikey") || key.include?("apikey")
       @iam_url = value if key.include?("iam_url")
       @url = value if key.include?("url")
       @username = value if key.include?("username")

--- a/resources/ibm-credentials.env
+++ b/resources/ibm-credentials.env
@@ -5,3 +5,5 @@ WATSON_URL=https://gateway-mo.stevieG.net/watson/api
 RONALDO_USERNAME=apikey
 RONALDO_PASSWORD=xyz
 MESSI_IAM_APIKEY=icp-xyz
+NATURAL_LANGUAGE_UNDERSTANDING_APIKEY=salah
+NATURAL_LANGUAGE_UNDERSTANDING_URL=https://gateway.messi.com

--- a/test/unit/test_base_service.rb
+++ b/test/unit/test_base_service.rb
@@ -68,6 +68,16 @@ class BaseServiceTest < Minitest::Test
     ENV.delete("IBM_CREDENTIALS_FILE")
   end
 
+  def test_set_credentials_from_path_in_env_nlu
+    file_path = File.join(File.dirname(__FILE__), "../../resources/ibm-credentials.env")
+    ENV["IBM_CREDENTIALS_FILE"] = file_path
+    service = IBMCloudSdkCore::BaseService.new(display_name: "Natural Language Understanding")
+    assert_equal(service.url, "https://gateway.messi.com")
+    assert_equal(service.token_manager.instance_variable_get(:@iam_apikey), "salah")
+    refute_nil(service)
+    ENV.delete("IBM_CREDENTIALS_FILE")
+  end
+
   def test_vcap_services
     ENV["VCAP_SERVICES"] = JSON.parse(File.read(Dir.getwd + "/resources/vcap-testing.json")).to_json
     service = IBMCloudSdkCore::BaseService.new(vcap_services_name: "salah", use_vcap_services: true)


### PR DESCRIPTION
I spent some time playing around with auth after releasing [0.3.2](https://github.com/IBM/ruby-sdk-core/releases/tag/v0.3.2) looking for other possible issues or improvements. In this PR, I am making sure that we look for both `iam_apikey` and `apikey`, and using `tr` instead of `sub`, see https://apidock.com/ruby/String/tr.