### PR TITLE
fix(auth): update headers instead of connector in core library

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 1.0.0.rc2
 commit = True
 message = [skip ci] Bump version: {current_version} -> {new_version}
 

--- a/lib/ibm_cloud_sdk_core/authenticators/basic_authenticator.rb
+++ b/lib/ibm_cloud_sdk_core/authenticators/basic_authenticator.rb
@@ -7,7 +7,7 @@ require_relative("../utils.rb")
 module IBMCloudSdkCore
   # Basic Authenticator
   class BasicAuthenticator < Authenticator
-    attr_accessor :username, :password
+    attr_accessor :username, :password, :authentication_type
     def initialize(vars)
       defaults = {
         username: nil,
@@ -21,8 +21,10 @@ module IBMCloudSdkCore
     end
 
     # Adds the Authorization header, if possible
-    def authenticate(req)
-      req.basic_auth(user: @username, pass: @password)
+    def authenticate(headers)
+      base64_authentication = Base64.strict_encode64("#{@username}:#{@password}")
+      headers["Authorization"] = "Basic #{base64_authentication}"
+      headers
     end
 
     # Checks if all the inputs needed are present

--- a/lib/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.rb
+++ b/lib/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.rb
@@ -19,8 +19,9 @@ module IBMCloudSdkCore
     end
 
     # Adds the Authorization header, if possible
-    def authenticate(connector)
-      connector.default_options.headers.add("Authorization", "Bearer #{@bearer_token}")
+    def authenticate(headers)
+      headers["Authorization"] = "Bearer #{@bearer_token}"
+      headers
     end
 
     # Checks if all the inputs needed are present

--- a/lib/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.rb
+++ b/lib/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.rb
@@ -25,9 +25,9 @@ module IBMCloudSdkCore
 
       validate
       @token_manager = CP4DTokenManager.new(
+        url: @url,
         username: @username,
         password: @password,
-        url: @url,
         disable_ssl_verification: @disable_ssl_verification
       )
     end

--- a/lib/ibm_cloud_sdk_core/authenticators/iam_authenticator.rb
+++ b/lib/ibm_cloud_sdk_core/authenticators/iam_authenticator.rb
@@ -26,8 +26,9 @@ module IBMCloudSdkCore
       @client_secret = vars[:client_secret]
       @disable_ssl_verification = vars[:disable_ssl_verification]
       @authentication_type = AUTH_TYPE_IAM
+
       validate
-      @token_manager = iam_token_manager(
+      @token_manager = IAMTokenManager.new(
         apikey: @apikey,
         url: @url,
         client_id: @client_id,
@@ -36,8 +37,9 @@ module IBMCloudSdkCore
       )
     end
 
-    def authenticate(connector)
-      connector.default_options.headers.add("Authorization", "Bearer #{@token_manager.access_token}")
+    def authenticate(headers)
+      headers["Authorization"] = "Bearer #{@token_manager.access_token}"
+      headers
     end
 
     def validate
@@ -46,14 +48,11 @@ module IBMCloudSdkCore
       raise ArgumentError.new('The apikey shouldn\'t start or end with curly brackets or quotes. Be sure to remove any {} and \" characters surrounding your apikey') if check_bad_first_or_last_char(@apikey)
 
       # Both the client id and secret should be provided or neither should be provided.
-      if !iam_client_id.nil? && !iam_client_secret.nil?
-        @iam_client_id = iam_client_id
-        @iam_client_secret = iam_client_secret
-      elsif iam_client_id.nil? && iam_client_secret.nil?
-        @iam_client_id = DEFAULT_CLIENT_ID
-        @iam_client_secret = DEFAULT_CLIENT_SECRET
-      else
-        raise ArgumentError.new("Only one of 'iam_client_id' or 'iam_client_secret' were specified, but both parameters should be specified together.")
+      if @client_id.nil? && @client_secret.nil?
+        @client_id = DEFAULT_CLIENT_ID
+        @client_secret = DEFAULT_CLIENT_SECRET
+      elsif @client_id.nil? || client_secret.nil?
+        raise ArgumentError.new("Only one of 'client_id' or 'client_secret' were specified, but both parameters should be specified together.")
       end
     end
   end

--- a/lib/ibm_cloud_sdk_core/base_service.rb
+++ b/lib/ibm_cloud_sdk_core/base_service.rb
@@ -9,6 +9,12 @@ require_relative("./detailed_response.rb")
 require_relative("./api_exception.rb")
 require_relative("./utils.rb")
 require_relative("./authenticators/authenticator")
+require_relative("./authenticators/basic_authenticator")
+require_relative("./authenticators/bearer_token_authenticator")
+require_relative("./authenticators/config_based_authenticator_factory")
+require_relative("./authenticators/iam_authenticator")
+require_relative("./authenticators/cp4d_authenticator")
+require_relative("./authenticators/no_auth_authenticator")
 
 NORMALIZER = lambda do |uri| # Custom URI normalizer when using HTTP Client
   HTTP::URI.parse uri
@@ -37,6 +43,7 @@ module IBMCloudSdkCore
         @url = config[:url] unless config.nil?
       end
 
+      @temp_headers = {}
       @conn = HTTP::Client.new(
         headers: {}
       ).use normalize_uri: { normalizer: NORMALIZER }

--- a/lib/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.rb
+++ b/lib/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.rb
@@ -18,6 +18,11 @@ module IBMCloudSdkCore
       @password = password
       @disable_ssl_verification = disable_ssl_verification
       super(url: url, token_name: TOKEN_NAME)
+      token
+    end
+
+    def access_token
+      @token_info[TOKEN_NAME]
     end
 
     def request_token

--- a/lib/ibm_cloud_sdk_core/token_managers/iam_token_manager.rb
+++ b/lib/ibm_cloud_sdk_core/token_managers/iam_token_manager.rb
@@ -16,7 +16,7 @@ module IBMCloudSdkCore
     REQUEST_TOKEN_RESPONSE_TYPE = "cloud_iam"
     TOKEN_NAME = "access_token"
 
-    attr_accessor :token_info, :user_access_token
+    attr_accessor :token_info, :token_name
     def initialize(
       apikey: nil,
       url: nil,
@@ -25,11 +25,16 @@ module IBMCloudSdkCore
       disable_ssl_verification: nil
     )
       @apikey = apikey
-      @url = url.nil? ? DEFAULT_IAM_URL : url
+      url = DEFAULT_IAM_URL if url.nil?
       @client_id = client_id
       @client_secret = client_secret
       @disable_ssl_verification = disable_ssl_verification
       super(url: url, token_name: TOKEN_NAME)
+      token
+    end
+
+    def access_token
+      @token_info[TOKEN_NAME]
     end
 
     private

--- a/lib/ibm_cloud_sdk_core/token_managers/jwt_token_manager.rb
+++ b/lib/ibm_cloud_sdk_core/token_managers/jwt_token_manager.rb
@@ -35,10 +35,6 @@ module IBMCloudSdkCore
       end
     end
 
-    def access_token
-      @token_info[@token_name]
-    end
-
     def ssl_verification(disable_ssl_verification)
       @disable_ssl_verification = disable_ssl_verification
     end

--- a/lib/ibm_cloud_sdk_core/version.rb
+++ b/lib/ibm_cloud_sdk_core/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IBMCloudSdkCore
-  VERSION = "0.3.3"
+  VERSION = "1.0.0.rc2"
 end

--- a/test/unit/test_base_service.rb
+++ b/test/unit/test_base_service.rb
@@ -179,10 +179,38 @@ class BaseServiceTest < Minitest::Test
   end
 
   def test_for_cp4d_authenticator
+    token_layout = {
+      "username": "dummy",
+      "role": "Admin",
+      "permissions": %w[administrator manage_catalog],
+      "sub": "admin",
+      "iss": "sss",
+      "aud": "sss",
+      "uid": "sss",
+      "iat": Time.now.to_i + 3600,
+      "exp": Time.now.to_i
+    }
+    token = JWT.encode token_layout, "secret", "HS256"
+    response = {
+      "accessToken" => token,
+      "token_type" => "Bearer",
+      "expires_in" => 3600,
+      "expiration" => 1_524_167_011,
+      "refresh_token" => "jy4gl91BQ"
+    }
+    stub_request(:get, "https://hello.world/v1/preauth/validateAuth")
+      .with(
+        headers: {
+          "Authorization" => "Basic aGVsbG86d29ybGQ=",
+          "Connection" => "close",
+          "Host" => "hello.world"
+        }
+      )
+      .to_return(status: 200, body: response.to_json, headers: {})
     authenticator = IBMCloudSdkCore::CloudPakForDataAuthenticator.new(
       username: "hello",
       password: "world",
-      url: "hello.world"
+      url: "https://hello.world"
     )
     refute_nil(authenticator)
   end

--- a/test/unit/test_iam_token_manager.rb
+++ b/test/unit/test_iam_token_manager.rb
@@ -8,21 +8,26 @@ WebMock.disable_net_connect!(allow_localhost: true)
 # Unit tests for the IAM Token Manager
 class IAMTokenManagerTest < Minitest::Test
   def test_request_token
+    token_layout = {
+      "username": "dummy",
+      "role": "Admin",
+      "permissions": %w[administrator manage_catalog],
+      "sub": "admin",
+      "iss": "sss",
+      "aud": "sss",
+      "uid": "sss",
+      "iat": Time.now.to_i + 3600,
+      "exp": Time.now.to_i
+    }
+    token = JWT.encode token_layout, "secret", "HS256"
     response = {
-      "access_token" => "oAeisG8yqPY7sFR_x66Z15",
+      "access_token" => token,
       "token_type" => "Bearer",
       "expires_in" => 3600,
       "expiration" => 1_524_167_011,
       "refresh_token" => "jy4gl91BQ"
     }
 
-    # Use default iam_url, client id/secret
-    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
-      apikey: "apikey",
-      url: "https://iam.cloud.ibm.com/identity/token",
-      client_id: "bx",
-      client_secret: "bx"
-    )
     stub_request(:post, "https://iam.cloud.ibm.com/identity/token")
       .with(
         body: { "apikey" => "apikey", "grant_type" => "urn:ibm:params:oauth:grant-type:apikey", "response_type" => "cloud_iam" },
@@ -33,16 +38,19 @@ class IAMTokenManagerTest < Minitest::Test
           "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(status: 200, body: response.to_json, headers: {})
+    # Use default iam_url, client id/secret
+    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
+      apikey: "apikey",
+      url: "https://iam.cloud.ibm.com/identity/token",
+      client_id: "bx",
+      client_secret: "bx"
+    )
     token_response = token_manager.send(:request_token)
     assert_equal(response, token_response)
   end
 
   def test_request_token_fails
     iam_url = "https://iam.cloud.ibm.com/identity/token"
-    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
-      apikey: "apikey",
-      url: iam_url
-    )
     response = {
       "code" => "500",
       "error" => "Oh no"
@@ -58,17 +66,14 @@ class IAMTokenManagerTest < Minitest::Test
         }
       ).to_return(status: 500, body: response.to_json, headers: {})
     assert_raises do
-      token_manager.send(:request_token)
+      IBMCloudSdkCore::IAMTokenManager.new(
+        apikey: "apikey",
+        url: iam_url
+      )
     end
   end
 
   def test_request_token_fails_catch_exception
-    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
-      apikey: "apikey",
-      url: "https://iam.cloud.ibm.com/identity/token",
-      client_id: "bx",
-      client_secret: "bx"
-    )
     response = {
       "code" => "500",
       "error" => "Oh no"
@@ -84,38 +89,18 @@ class IAMTokenManagerTest < Minitest::Test
         }
       ).to_return(status: 401, body: response.to_json, headers: {})
     begin
-      token_manager.send(:request_token)
+      IBMCloudSdkCore::IAMTokenManager.new(
+        apikey: "apikey",
+        url: "https://iam.cloud.ibm.com/identity/token",
+        client_id: "bx",
+        client_secret: "bx"
+      )
     rescue IBMCloudSdkCore::ApiException => e
       assert(e.to_s.instance_of?(String))
     end
   end
 
-  def test_is_token_expired
-    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
-      apikey: "apikey",
-      url: "https://url.com",
-      client_id: "bx",
-      client_secret: "bx"
-    )
-
-    assert(token_manager.send(:token_expired?))
-    token_manager.instance_variable_set(:@time_to_live, 3600)
-    token_manager.instance_variable_set(:@expire_time, Time.now.to_i + 6000)
-    refute(token_manager.send(:token_expired?))
-    token_manager.instance_variable_set(:@time_to_live, 3600)
-    token_manager.instance_variable_set(:@expire_time, Time.now.to_i - 3600)
-    assert(token_manager.send(:token_expired?))
-  end
-
   def test_get_token
-    iam_url = "https://iam.cloud.ibm.com/identity/token"
-    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
-      apikey: "apikey",
-      url: iam_url,
-      client_id: "bx",
-      client_secret: "bx"
-    )
-
     access_token_layout = {
       "username" => "dummy",
       "role" => "Admin",
@@ -148,8 +133,14 @@ class IAMTokenManagerTest < Minitest::Test
           "Host" => "iam.cloud.ibm.com"
         }
       ).to_return(status: 200, body: response.to_json, headers: {})
-    token = token_manager.token
-    assert_equal(access_token, token)
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    token_manager = IBMCloudSdkCore::IAMTokenManager.new(
+      apikey: "apikey",
+      url: iam_url,
+      client_id: "bx",
+      client_secret: "bx"
+    )
+    assert_equal(token_manager.access_token, access_token)
   end
 
   def test_client_id_only

--- a/test/unit/test_icp4d_token_manager.rb
+++ b/test/unit/test_icp4d_token_manager.rb
@@ -8,19 +8,25 @@ WebMock.disable_net_connect!(allow_localhost: true)
 # Unit tests for the CP4D Token Manager
 class CP4DTokenManagerTest < Minitest::Test
   def test_request_token
+    token_layout = {
+      "username": "dummy",
+      "role": "Admin",
+      "permissions": %w[administrator manage_catalog],
+      "sub": "admin",
+      "iss": "sss",
+      "aud": "sss",
+      "uid": "sss",
+      "iat": Time.now.to_i + 3600,
+      "exp": Time.now.to_i
+    }
+    token = JWT.encode token_layout, "secret", "HS256"
     response = {
-      "access_token" => "oAeisG8yqPY7sFR_x66Z15",
+      "accessToken" => token,
       "token_type" => "Bearer",
       "expires_in" => 3600,
       "expiration" => 1_524_167_011,
       "refresh_token" => "jy4gl91BQ"
     }
-
-    token_manager = IBMCloudSdkCore::CP4DTokenManager.new(
-      url: "https://the.sixth.one",
-      username: "you",
-      password: "me"
-    )
     stub_request(:get, "https://the.sixth.one/v1/preauth/validateAuth")
       .with(
         headers: {
@@ -28,16 +34,17 @@ class CP4DTokenManagerTest < Minitest::Test
           "Host" => "the.sixth.one"
         }
       ).to_return(status: 200, body: response.to_json, headers: {})
-    token_response = token_manager.send(:request_token)
-    assert_equal(response, token_response)
-  end
 
-  def test_request_token_fails
     token_manager = IBMCloudSdkCore::CP4DTokenManager.new(
       url: "https://the.sixth.one",
       username: "you",
       password: "me"
     )
+    token_response = token_manager.send(:request_token)
+    assert_equal(response, token_response)
+  end
+
+  def test_request_token_fails
     response = {
       "code" => "500",
       "error" => "Oh no"
@@ -50,7 +57,11 @@ class CP4DTokenManagerTest < Minitest::Test
         }
       ).to_return(status: 500, body: response.to_json, headers: {})
     begin
-      token_manager.send(:request_token)
+      IBMCloudSdkCore::CP4DTokenManager.new(
+        url: "https://the.sixth.one",
+        username: "you",
+        password: "me"
+      )
     rescue IBMCloudSdkCore::ApiException => e
       assert(e.to_s.instance_of?(String))
     end


### PR DESCRIPTION
Few things came up during integration tests, this PR fixes issue with IAM auth and updates auth headers instead of the whole connection object. Below is the snippet of Assistant service that I did the integration and unit testing with:

Method:

```ruby
    def message(workspace_id:, input: nil, intents: nil, entities: nil, alternate_intents: nil, context: nil, output: nil, nodes_visited_details: nil)
      raise ArgumentError.new("workspace_id must be provided") if workspace_id.nil?

      headers = {
      }
      sdk_headers = Common.new.get_sdk_headers("conversation", "V1", "message")
      headers.merge!(sdk_headers)

      params = {
        "version" => @version,
        "nodes_visited_details" => nodes_visited_details
      }

      data = {
        "input" => input,
        "intents" => intents,
        "entities" => entities,
        "alternate_intents" => alternate_intents,
        "context" => context,
        "output" => output
      }

      method_url = "/v1/workspaces/%s/message" % [ERB::Util.url_encode(workspace_id)]

      headers = authenticator.authenticate(headers)
      response = request(
        method: "POST",
        url: method_url,
        headers: headers,
        params: params,
        json: data,
        accept_json: true
      )
      response
    end
```

Constructor:

```ruby
    def initialize(args = {})
      @__async_initialized__ = false
      defaults = {}
      defaults[:version] = nil
      defaults[:url] = "https://gateway.watsonplatform.net/assistant/api"
      defaults[:authenticator] = nil
      defaults[:authentication_type] = nil
      args = defaults.merge(args)
      args[:vcap_services_name] = "conversation"
      @version = args[:version]
      super
      raise ArgumentError.new("url must be provided") if @url.nil?
      raise ArgumentError.new("version must be provided") if @version.nil?
    end
```

Auth:
```ruby
      authenticator = IBMCloudSdkCore::IamAuthenticator.new(
        apikey: ENV["ASSISTANT_APIKEY"],
        version: "2018-02-16"
      )
      @service = IBMWatson::AssistantV1.new(
        version: "2018-02-16",
        url: ENV["ASSISTANT_URL"],
        authenticator: authenticator
      )

```