### PR TITLE
refactor: moke authenticator check consistent with generator

### DIFF
--- a/lib/ibm_cloud_sdk_core/authenticators/config_based_authenticator_factory.rb
+++ b/lib/ibm_cloud_sdk_core/authenticators/config_based_authenticator_factory.rb
@@ -26,6 +26,8 @@ module IBMCloudSdkCore
       else
         auth_type = config[:auth_type]
       end
+      config.delete(:url) unless config[:url].nil?
+      config[:url] = config[:auth_url] unless config[:auth_url].nil?
       return BasicAuthenticator.new(config) if auth_type.casecmp(AUTH_TYPE_BASIC).zero?
       return BearerTokenAuthenticator.new(config) if auth_type.casecmp(AUTH_TYPE_BEARER_TOKEN).zero?
       return CloudPakForDataAuthenticator.new(config) if auth_type.casecmp(AUTH_TYPE_CP4D).zero?

--- a/lib/ibm_cloud_sdk_core/base_service.rb
+++ b/lib/ibm_cloud_sdk_core/base_service.rb
@@ -23,20 +23,19 @@ end
 module IBMCloudSdkCore
   # Class for interacting with the API
   class BaseService
-    attr_accessor :display_name, :service_url, :disable_ssl_verification
+    attr_accessor :service_name, :service_url, :disable_ssl_verification
     attr_reader :conn, :authenticator
     def initialize(vars)
       defaults = {
         authenticator: nil,
         disable_ssl_verification: false,
-        display_name: nil
+        service_name: nil
       }
       vars = defaults.merge(vars)
       @service_url = vars[:service_url]
       @authenticator = vars[:authenticator]
       @disable_ssl_verification = vars[:disable_ssl_verification]
-      @display_name = vars[:display_name]
-      @service_name = @display_name.tr(" ", "_").downcase unless @display_name.nil?
+      @service_name = vars[:service_name]
 
       raise ArgumentError.new("authenticator must be provided") if @authenticator.nil?
 

--- a/resources/ibm-credentials.env
+++ b/resources/ibm-credentials.env
@@ -11,3 +11,5 @@ LEO_MESSI_BEARER_TOKEN=argentina
 LEO_MESSI_AUTH_TYPE=bearerToken
 WRONG_APIKEY={key
 RED_SOX_AUTH_TYPE=noAuth
+MY_SERVICE_APIKEY=mesSi
+MY_SERVICE_AUTH_URL=https://my.link/identity/token

--- a/test/unit/test_base_service.rb
+++ b/test/unit/test_base_service.rb
@@ -48,10 +48,11 @@ class BaseServiceTest < Minitest::Test
     ENV["IBM_CREDENTIALS_FILE"] = file_path
     authenticator = IBMCloudSdkCore::ConfigBasedAuthenticatorFactory.new.get_authenticator(service_name: "red_sox")
     service = IBMCloudSdkCore::BaseService.new(
-      display_name: "Assistant",
+      service_name: "assistant",
       authenticator: authenticator
     )
     refute_nil(service)
+    ENV.delete("IBM_CREDENTIALS_FILE")
   end
 
   def test_correct_creds_and_headers
@@ -60,7 +61,7 @@ class BaseServiceTest < Minitest::Test
       password: "password"
     )
     service = IBMCloudSdkCore::BaseService.new(
-      display_name: "Assistant",
+      service_name: "assistant",
       authenticator: authenticator
     )
     service.add_default_headers(
@@ -85,7 +86,7 @@ class BaseServiceTest < Minitest::Test
     file_path = File.join(File.dirname(__FILE__), "../../resources/ibm-credentials.env")
     ENV["IBM_CREDENTIALS_FILE"] = file_path
     authenticator = IBMCloudSdkCore::ConfigBasedAuthenticatorFactory.new.get_authenticator(service_name: "leo_messi")
-    service = IBMCloudSdkCore::BaseService.new(display_name: "Leo Messi", url: "some.url", authenticator: authenticator)
+    service = IBMCloudSdkCore::BaseService.new(service_name: "leo_messi", url: "some.url", authenticator: authenticator)
     assert_equal(authenticator.authentication_type, "bearerToken")
     refute_nil(service)
   end
@@ -93,9 +94,9 @@ class BaseServiceTest < Minitest::Test
   def test_vcap_services
     ENV["VCAP_SERVICES"] = JSON.parse(File.read(Dir.getwd + "/resources/vcap-testing.json")).to_json
     authenticator = IBMCloudSdkCore::ConfigBasedAuthenticatorFactory.new.get_authenticator(service_name: "salah")
-    service = IBMCloudSdkCore::BaseService.new(display_name: "salah", authenticator: authenticator)
+    service = IBMCloudSdkCore::BaseService.new(service_name: "salah", authenticator: authenticator)
     assert_equal(authenticator.username, "mo")
-    assert_equal(service.display_name, "salah")
+    assert_equal(service.service_name, "salah")
   end
 
   def test_dummy_request
@@ -107,7 +108,7 @@ class BaseServiceTest < Minitest::Test
         }
       ).to_return(status: 200, body: "", headers: {})
     authenticator = IBMCloudSdkCore::ConfigBasedAuthenticatorFactory.new.get_authenticator(service_name: "salah")
-    service = IBMCloudSdkCore::BaseService.new(display_name: "Salah", authenticator: authenticator, service_url: "https://we.the.best")
+    service = IBMCloudSdkCore::BaseService.new(service_name: "salah", authenticator: authenticator, service_url: "https://we.the.best")
     service_response = service.request(method: "GET", url: "/music", headers: {})
     assert_equal("", service_response.result)
   end
@@ -115,7 +116,7 @@ class BaseServiceTest < Minitest::Test
   def test_dummy_request_form_data
     authenticator = IBMCloudSdkCore::BearerTokenAuthenticator.new(bearer_token: "token")
     service = IBMCloudSdkCore::BaseService.new(
-      display_name: "Assistant",
+      service_name: "assistant",
       authenticator: authenticator,
       service_url: "https://gateway.watsonplatform.net/"
     )
@@ -150,7 +151,7 @@ class BaseServiceTest < Minitest::Test
         }
       ).to_return(status: 500, body: response.to_json, headers: {})
     authenticator = IBMCloudSdkCore::ConfigBasedAuthenticatorFactory.new.get_authenticator(service_name: "salah")
-    service = IBMCloudSdkCore::BaseService.new(display_name: "Salah", authenticator: authenticator, service_url: "https://we.the.best")
+    service = IBMCloudSdkCore::BaseService.new(service_name: "salah", authenticator: authenticator, service_url: "https://we.the.best")
     assert_raises IBMCloudSdkCore::ApiException do
       service.request(method: "GET", url: "/music", headers: {})
     end
@@ -176,7 +177,7 @@ class BaseServiceTest < Minitest::Test
       password: "icp-xyz"
     )
     service = IBMCloudSdkCore::BaseService.new(
-      display_name: "Assistant",
+      service_name: "assistant",
       authenticator: authenticator,
       service_url: "https://we.the.best"
     )

--- a/test/unit/test_jwt_token_manager.rb
+++ b/test/unit/test_jwt_token_manager.rb
@@ -125,7 +125,7 @@ class JWTTokenManagerTest < Minitest::Test
       disable_ssl_verification: true
     )
     IBMCloudSdkCore::BaseService.new(
-      display_name: "Assistant",
+      service_name: "assistant",
       service_url: "http://the.com",
       authenticator: authenticator
     )


### PR DESCRIPTION
This PR:

- moves the logic for service name into utils because we are changing the logic for authenticator in the generated class.
- make sure `auth_url` is passed to authenticator when grabbing external creds.
- add tests for the changes