### PR TITLE
Refactor SSL warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,20 @@ require "ibm_cloud_sdk_core"
 ```
 
 ## Authentication Types
-There are several flavors of authentication supported in this package. To specify the intended authentication pattern to use, the user can pass in the parameter `authentication_type`. This parameter is optional, but it may become required in a future major release. The options for this parameter are `basic`, `iam`, and `icp4d`.
+There are several flavors of authentication supported in this package. To specify the intended authentication pattern to use, the user can pass in the parameter `authentication_type`. This parameter is optional, but it may become required in a future major release. The options for this parameter are `basic`, `iam`, `bearer_token`  and `cp4d`.
 
- ### basic
+### basic
 This indicates Basic Auth is to be used. Users will pass in a `username` and `password` and the SDK will generate a Basic Auth header to send with requests to the service.
 
- ### iam
-This indicates that IAM token authentication is to be used. Users can pass in an `iam_apikey` or an `iam_access_token`. If an API key is used, the SDK will manage the token for the user. In either case, the SDK will generate a Bearer Auth header to send with requests to the service.
+## bearer token
+This indicates that bearer token authentication is to be used. Users can pass in an `bearer_token`, and SDK will generate a Bearer Auth header to send with requests to the service.
 
- ### icp4d
-This indicates that the service is an instance of ICP4D, which has its own version of token authentication. Users can pass in a `username` and `password`, or an `icp4d_access_token`. If a username and password is given, the SDK will manage the token for the user.
-A `icp4d_url` is **required** for this type. In order to use an SDK-managed token with ICP4D authentication, this option **must** be passed in.
+### iam
+This indicates that IAM token authentication is to be used. Users can pass in an `iam_apikey`. The SDK will manage the token for the user and it will generate a Bearer Auth header to send with requests to the service.
+
+### cp4d
+This indicates that the service is an instance of ICP4D, which has its own version of token authentication. Users can pass in a `username` and `password`. If a username and password is given, the SDK will manage the token for the user.
+A `cp4d_url` is **required** for this type. In order to use an SDK-managed token with ICP4D authentication, this option **must** be passed in.
 
 ## Issues
 

--- a/lib/ibm_cloud_sdk_core/base_service.rb
+++ b/lib/ibm_cloud_sdk_core/base_service.rb
@@ -44,6 +44,7 @@ module IBMCloudSdkCore
         @service_url = config[:url] unless config.nil?
       end
 
+      configure_http_client(disable_ssl_verification: @disable_ssl_verification)
       @temp_headers = {}
       @conn = HTTP::Client.new(
         headers: {}
@@ -102,6 +103,8 @@ module IBMCloudSdkCore
       return DetailedResponse.new(response: response) if (200..299).cover?(response.code)
 
       raise ApiException.new(response: response)
+    rescue OpenSSL::SSL::SSLError
+      raise StandardError.new("If you're trying to call a service on ICP or Cloud Pak for Data, you may not have a valid SSL certificate. If you need to access the service without setting that up, try using the disableSslVerification option in your authentication configuration and/or setting DisableSslVerification(true); on your service.")
     end
 
     # @note Chainable

--- a/lib/ibm_cloud_sdk_core/base_service.rb
+++ b/lib/ibm_cloud_sdk_core/base_service.rb
@@ -23,8 +23,8 @@ end
 module IBMCloudSdkCore
   # Class for interacting with the API
   class BaseService
-    attr_accessor :service_name, :service_url, :disable_ssl_verification
-    attr_reader :conn, :authenticator
+    attr_accessor :service_name, :service_url
+    attr_reader :conn, :authenticator, :disable_ssl_verification
     def initialize(vars)
       defaults = {
         authenticator: nil,
@@ -49,6 +49,10 @@ module IBMCloudSdkCore
       @conn = HTTP::Client.new(
         headers: {}
       ).use normalize_uri: { normalizer: NORMALIZER }
+    end
+
+    def disable_ssl_verification=(disable_ssl_verification)
+      configure_http_client(disable_ssl_verification: disable_ssl_verification)
     end
 
     def add_default_headers(headers: {})
@@ -104,7 +108,7 @@ module IBMCloudSdkCore
 
       raise ApiException.new(response: response)
     rescue OpenSSL::SSL::SSLError
-      raise StandardError.new("If you're trying to call a service on ICP or Cloud Pak for Data, you may not have a valid SSL certificate. If you need to access the service without setting that up, try using the disableSslVerification option in your authentication configuration and/or setting DisableSslVerification(true); on your service.")
+      raise StandardError.new("If you're trying to call a service on ICP or Cloud Pak for Data, you may not have a valid SSL certificate. If you need to access the service without setting that up, try using the disable_ssl_verification option in your authentication configuration and/or setting disable_ssl_verification; on your service.")
     end
 
     # @note Chainable

--- a/lib/ibm_cloud_sdk_core/version.rb
+++ b/lib/ibm_cloud_sdk_core/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IBMCloudSdkCore
-  VERSION = "1.0.0.rc4"
+  VERSION = "1.0.0.rc5"
 end


### PR DESCRIPTION
This PR:
- Catches the `SSL` error and throws a warning for ICP/CP4D users.
- Updates Readme.