### PR TITLE
feat(BaseService): add new method configure_service to BaseService class & enhance vcap parsing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Pull Requests
+
+If you want to contribute to the repository, here's a quick guide:
+  1. Fork the repository  
+
+  2. Clone the repository into a local directory.  
+
+  3. Install `Ruby`. Supported versions in the core are:
+     - 2.3.7
+     - 2.4.5
+     - 2.5.3
+  4. Run
+     ```sh
+     gem install bundler
+     bundle install
+     ```
+
+  5. Make your code changes as needed.  Be sure to add new tests for any new or modified functionality.  
+
+  6. Test your changes:
+     ```sh
+     bundle exec rake
+     ```  
+  7. Commit your changes:
+  * Commit messages should follow the [Angular commit message guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
+  This is because this project uses `semantic-release` for build release automation, and `semantic-release` uses
+  this commit message style for determining release versions and generating changelogs.
+  To make this easier, we recommend using the [Commitizen CLI](https://github.com/commitizen/cz-cli)
+  with the `cz-conventional-changelog` adapter.  
+
+  9. Push your commit(s) to your fork and submit a pull request to the **master** branch.
+
+# Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+   have the right to submit it under the open source license
+   indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+   of my knowledge, is covered under an appropriate open source
+   license and I have the right under that license to submit that
+   work with modifications, whether created in whole or in part
+   by me, under the same open source license (unless I am
+   permitted to submit under a different license), as indicated
+   in the file; or
+
+(c) The contribution was provided directly to me by some other
+   person who certified (a), (b) or (c) and I have not modified
+   it.
+
+(d) I understand and agree that this project and the contribution
+   are public and that a record of the contribution (including all
+   personal information I submit with it, including my sign-off) is
+   maintained indefinitely and may be redistributed consistent with
+   this project or the open source license(s) involved.
+
+## Additional Resources
++ [General GitHub documentation](https://help.github.com/)
++ [GitHub pull request documentation](https://help.github.com/send-pull-requests/)
+
+[dw]: https://developer.ibm.com/answers/questions/ask.html
+[stackoverflow]: http://stackoverflow.com/questions/ask?tags=ibm
+[dep]: https://github.com/golang/dep

--- a/lib/ibm_cloud_sdk_core/utils.rb
+++ b/lib/ibm_cloud_sdk_core/utils.rb
@@ -16,6 +16,13 @@ def check_bad_first_or_last_char(str)
   return str.start_with?("{", "\"") || str.end_with?("}", "\"") unless str.nil?
 end
 
+# checks if the provided value is truthy
+def explicitly_true(value)
+  return value.to_s.casecmp("true").zero? unless value.nil?
+
+  false
+end
+
 # Initiates the credentials based on the credential file
 def load_from_credential_file(service_name, separator = "=")
   credential_file_path = ENV["IBM_CREDENTIALS_FILE"]
@@ -63,10 +70,20 @@ def load_from_vcap_services(service_name)
   vcap_services = ENV["VCAP_SERVICES"]
   unless vcap_services.nil?
     services = JSON.parse(vcap_services)
+    credentials = ""
+    # search for matching inner name value
+    services.each do |_key, val|
+      service = val.detect { |item| item["name"] == service_name }
+      credentials = service["credentials"] unless service.nil?
+      break unless credentials.nil? || credentials.empty?
+    end
     config = {}
-    credentials = services[service_name][0]["credentials"] if services.key?(service_name)
-    return config if credentials.nil?
-
+    # if no matching inner key is found, then search outer keys
+    if credentials.nil? || credentials.empty?
+      credentials = services[service_name][0]["credentials"] if services.key?(service_name) && !services[service_name].empty?
+      return config if credentials.nil? || credentials.empty?
+    end
+    # store credentials
     credentials.each do |key, val|
       config.store(key.to_sym, val)
     end

--- a/resources/ibm-credentials.env
+++ b/resources/ibm-credentials.env
@@ -1,5 +1,6 @@
 VISUAL_RECOGNITION_APIKEY=mesSi
 VISUAL_RECOGNITION_URL=https://gateway.ronaldo.com
+VISUAL_RECOGNITION_DISABLE_SSL=true
 WATSON_APIKEY=salaH
 WATSON_URL=https://gateway-mo.stevieG.net/watson/api
 RONALDO_USERNAME=apikey

--- a/resources/vcap-testing.json
+++ b/resources/vcap-testing.json
@@ -1,20 +1,159 @@
 {
   "salah": [
-  	{
-  		"credentials": {
-  			"password": "password",
-  			"url": "https://gateway.net/salah/api",
-  			"username": "mo"
-  		},
-  		"label": "goat",
-  		"name": "salah",
-  		"plan": "standard",
-  		"tags": [
-  			"watson",
-  			"ibm_created",
-  			"ibm_dedicated_public",
-  			"lite"
-  		]
-  	}
+    {
+      "credentials": {
+        "password": "password",
+        "url": "https://gateway.net/salah/api",
+        "username": "mo"
+      },
+      "label": "goat",
+      "name": "salah",
+      "plan": "standard",
+      "tags": [
+        "watson",
+        "ibm_created",
+        "ibm_dedicated_public",
+        "lite"
+      ]
+    }
+  ],
+  "visual_recognition": [
+    {
+      "credentials": {
+        "password": "password",
+        "url": "https://gateway.net/visual_recognition/api",
+        "username": "mo"
+      },
+      "label": "goat",
+      "name": "visual_recognition",
+      "plan": "standard",
+      "tags": [
+        "watson",
+        "ibm_created",
+        "ibm_dedicated_public",
+        "lite"
+      ]
+    }
+  ],
+  "devops_insights": [
+    {
+      "credentials": {
+        "password": "password",
+        "url": "https://gateway.net/visual_recognition/api",
+        "username": "mo"
+      },
+      "label": "goat",
+      "name": "devops_insights_1",
+      "plan": "standard",
+      "tags": [
+        "watson",
+        "ibm_created",
+        "ibm_dedicated_public",
+        "lite"
+      ]
+    },
+    {
+      "credentials": {
+        "password": "password",
+        "url": "https://ibmtesturl.net/devops_insights/api",
+        "username": "mo"
+      },
+      "label": "goat",
+      "name": "devops_insights",
+      "plan": "standard",
+      "tags": [
+        "watson",
+        "ibm_created",
+        "ibm_dedicated_public",
+        "lite"
+      ]
+    }
+  ],
+  "no_matching_name": [
+    {
+      "name": "different_name_two",
+      "label": "different_name_two",
+      "plan": "different_name__two_plan",
+      "credentials": {
+        "url": "https://gateway.watsonplatform.net/different-name-two/api",
+        "username": "not-a-username",
+        "password": "not-a-password"
+      }
+    },
+    {
+      "name": "different_name",
+      "label": "different_name",
+      "plan": "different_name_plan",
+      "credentials": {
+        "url": "https://gateway.watsonplatform.net/different-name/api",
+        "username": "not-a-username",
+        "password": "not-a-password"
+      }
+    }
+  ],
+  "key_to_service_entry_1": [
+    {
+      "name": "service_entry_key_and_key_to_service_entries",
+      "label": "devops-insights",
+      "plan": "standard",
+      "credentials": {
+        "url": "https://on.the.toolchainplatform.net/devops-insights/api",
+        "username": "not-a-username",
+        "password": "not-a-password"
+      }
+    },
+    {
+      "name": "service_entry_key_and_key_to_service_entries_two",
+      "label": "devops-insights",
+      "plan": "standard",
+      "credentials": {
+        "url": "https://on.the.toolchainplatform.net/devops-insights-2/api",
+        "username": "not-a-username",
+        "password": "not-a-password"
+      }
+    }
+  ],
+  "key_to_service_entry_2": [
+    {
+      "label": "devops-insights",
+      "plan": "standard",
+      "credentials": {
+        "url": "https://on.the.toolchainplatform.net/devops-insights-3/api",
+        "username": "not-a-username-3",
+        "password": "not-a-password-3"
+      }
+    }
+  ],
+  "service_entry_key_and_key_to_service_entries": [
+    {
+      "name": "service_entry_key-2",
+      "label": "devops-insights",
+      "plan": "elite",
+      "credentials": {
+        "url": "https://on.the.toolchainplatform.net/devops-insights-2/api",
+        "username": "not-a-username-2",
+        "password": "not-a-password-2"
+      }
+    }
+  ],
+  "empty_service": [
+
+  ],
+  "no-creds-service": [
+    {
+      "name": "no-creds-service-one",
+      "label": "devops-insights",
+      "plan": "elite",
+      "credentials": {
+        "url": "https://on.the.toolchainplatform.net/no-creds-service-one/api",
+        "username": "not-a-username-2",
+        "password": "not-a-password-2"
+      }
+    },
+    {
+      "name": "no-creds-service-two",
+      "label": "devops-insights",
+      "plan": "elite"
+    }
   ]
 }

--- a/test/unit/test_utils.rb
+++ b/test/unit/test_utils.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require("json")
+require("jwt")
+require_relative("./../test_helper.rb")
+require_relative("./../../lib/ibm_cloud_sdk_core/authenticators/basic_authenticator")
+require_relative("./../../lib/ibm_cloud_sdk_core/authenticators/config_based_authenticator_factory")
+require("webmock/minitest")
+
+WebMock.disable_net_connect!(allow_localhost: true)
+
+# Unit tests for the utility methods
+class UtilsTest < Minitest::Test
+  def test_explicitly_true
+    assert(explicitly_true("true"))
+    assert(explicitly_true("True"))
+    assert(explicitly_true(true))
+
+    assert_equal(explicitly_true("false"), false)
+    assert_equal(explicitly_true("False"), false)
+    assert_equal(explicitly_true("someothervalue"), false)
+    assert_equal(explicitly_true(""), false)
+    assert_equal(explicitly_true(false), false)
+    assert_equal(explicitly_true(nil), false)
+  end
+end


### PR DESCRIPTION
Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/1142

Changes:
- moved the external configuration code outside of the constructor into it's own method.
- for compatibility, the constructor calls the new method until we move to the service factory's complete implementation.
- disable_ssl is now also configurable from external config to be consistent with the other cores.
- (Potential bug fix) moved the instantiation of ``@conn`` in the constructor, to prior to configuring the http client. Before, if disable ssl was set to true through the constructor arguments, this would cause a failure in the ```configure_http_client``` method.
- enhanced vcap parsing to follow the latest service factory [design](https://github.ibm.com/CloudEngineering/openapi-sdkgen/wiki/Design-Of-Service-Config-Changes#external-config-behavior)
- Added a unit test for utility methods
- Added CONTRIBUTING.md since apparently this was missing 😄 