### PR TITLE
fix: allow '=' character in environment config values

### DIFF
--- a/lib/ibm_cloud_sdk_core/utils.rb
+++ b/lib/ibm_cloud_sdk_core/utils.rb
@@ -44,7 +44,7 @@ def load_from_credential_file(service_name, separator = "=")
   file_contents = File.open(credential_file_path, "r")
   config = {}
   file_contents.each_line do |line|
-    key_val = line.strip.split(separator)
+    key_val = line.strip.split(separator, 2)
     if key_val.length == 2 && !line.start_with?("#")
       key = parse_key(key_val[0].downcase, service_name) unless key_val[0].nil?
       config.store(key.to_sym, key_val[1]) unless key.nil?

--- a/resources/ibm-credentials.env
+++ b/resources/ibm-credentials.env
@@ -10,10 +10,19 @@ NATURAL_LANGUAGE_UNDERSTANDING_URL=https://gateway.messi.com
 NATURAL_LANGUAGE_UNDERSTANDING_AUTH_TYPE=bearertoken
 MANE_APIKEY=sadio
 MANE_URL=https://gateway.lfc.com
-MANE_AUTH_TYPE=bearertoken=wrong
 LEO_MESSI_BEARER_TOKEN=argentina
 LEO_MESSI_AUTH_TYPE=bearerToken
 WRONG_APIKEY={key
 RED_SOX_AUTH_TYPE=noAuth
 MY_SERVICE_APIKEY=mesSi
 MY_SERVICE_AUTH_URL=https://my.link/identity/token
+
+# Service1 auth properties configured with IAM and a token containing '='
+SERVICE_1_AUTH_TYPE=iam
+SERVICE_1_APIKEY=V4HXmoUtMjohnsnow=KotN
+SERVICE_1_CLIENT_ID=somefake========id
+SERVICE_1_CLIENT_SECRET===my-client-secret==
+SERVICE_1_AUTH_URL=https://iamhost/iam/api=
+
+# Service1 service properties
+SERVICE_1_URL=service1.com/api

--- a/resources/vcap-testing.json
+++ b/resources/vcap-testing.json
@@ -155,5 +155,21 @@
       "label": "devops-insights",
       "plan": "elite"
     }
+  ],
+  "equals-sign-test": [
+    {
+       "name": "equals-sign-test",
+       "label": "equals_sign",
+       "plan": "standard",
+       "credentials": {
+          "apikey": "V4HXmoUtMjohnsnow=KotN",
+          "iam_apikey_description": "Auto generated apikey...",
+          "iam_apikey_name": "auto-generated-apikey-111-222-333",
+          "iam_role_crn": "crn:v1:bluemix:public:iam::::serviceRole:Manager",
+          "iam_serviceid_crn": "crn:v1:staging:public:iam-identity::a/::serviceid:ServiceID-1234",
+          "url": "https://gateway.watsonplatform.net/testService",
+          "iam_url": "https://iamhost/iam/api="
+       }
+    }
   ]
 }

--- a/test/unit/test_utils.rb
+++ b/test/unit/test_utils.rb
@@ -23,4 +23,94 @@ class UtilsTest < Minitest::Test
     assert_equal(explicitly_true(false), false)
     assert_equal(explicitly_true(nil), false)
   end
+
+  def test_get_configuration_credential_file
+    file_path = File.join(File.dirname(__FILE__), "../../resources/ibm-credentials.env")
+    ENV["IBM_CREDENTIALS_FILE"] = file_path
+    # get properties
+    config = get_service_properties("service_1")
+    auth_type = config[:auth_type] unless config.nil?
+    apikey = config[:apikey] unless config.nil?
+    auth_url = config[:auth_url] unless config.nil?
+    client_id = config[:client_id] unless config.nil?
+    client_secret = config[:client_secret] unless config.nil?
+    service_url = config[:url] unless config.nil?
+
+    assert !auth_type.nil?
+    assert !apikey.nil?
+    assert !auth_url.nil?
+    assert !client_id.nil?
+    assert !client_secret.nil?
+    assert !service_url.nil?
+
+    assert_equal("iam", auth_type)
+    assert_equal("V4HXmoUtMjohnsnow=KotN", apikey)
+    assert_equal("https://iamhost/iam/api=", auth_url)
+    assert_equal("somefake========id", client_id)
+    assert_equal("==my-client-secret==", client_secret)
+    assert_equal("service1.com/api", service_url)
+    ENV.delete("IBM_CREDENTIALS_FILE")
+  end
+
+  def test_get_configuration_from_env
+    # Service1 auth properties configured with IAM and a token containing '='
+    ENV["SERVICE_1_AUTH_TYPE"] = "iam"
+    ENV["SERVICE_1_APIKEY"] = "V4HXmoUtMjohnsnow=KotN"
+    ENV["SERVICE_1_CLIENT_ID"] = "somefake========id"
+    ENV["SERVICE_1_CLIENT_SECRET"] = "==my-client-secret=="
+    ENV["SERVICE_1_AUTH_URL"] = "https://iamhost/iam/api="
+    # Service1 service properties
+    ENV["SERVICE_1_URL"] = "service1.com/api"
+    # get properties
+    config = get_service_properties("service_1")
+    auth_type = config[:auth_type] unless config.nil?
+    apikey = config[:apikey] unless config.nil?
+    auth_url = config[:auth_url] unless config.nil?
+    client_id = config[:client_id] unless config.nil?
+    client_secret = config[:client_secret] unless config.nil?
+    service_url = config[:url] unless config.nil?
+
+    assert !auth_type.nil?
+    assert !apikey.nil?
+    assert !auth_url.nil?
+    assert !client_id.nil?
+    assert !client_secret.nil?
+    assert !service_url.nil?
+
+    assert_equal("iam", auth_type)
+    assert_equal("V4HXmoUtMjohnsnow=KotN", apikey)
+    assert_equal("https://iamhost/iam/api=", auth_url)
+    assert_equal("somefake========id", client_id)
+    assert_equal("==my-client-secret==", client_secret)
+    assert_equal("service1.com/api", service_url)
+
+    ENV.delete("SERVICE_1_AUTH_TYPE")
+    ENV.delete("SERVICE_1_APIKEY")
+    ENV.delete("SERVICE_1_CLIENT_ID")
+    ENV.delete("SERVICE_1_CLIENT_SECRET")
+    ENV.delete("SERVICE_1_AUTH_URL")
+    ENV.delete("SERVICE_1_URL")
+  end
+
+  def test_get_configuration_from_vcap
+    ENV["VCAP_SERVICES"] = JSON.parse(File.read(Dir.getwd + "/resources/vcap-testing.json")).to_json
+    # get properties
+    config = get_service_properties("equals-sign-test")
+    auth_type = config[:auth_type] unless config.nil?
+    apikey = config[:apikey] unless config.nil?
+    iam_url = config[:iam_url] unless config.nil?
+    service_url = config[:url] unless config.nil?
+
+    assert !auth_type.nil?
+    assert !apikey.nil?
+    assert !iam_url.nil?
+    assert !service_url.nil?
+
+    assert_equal("iam", auth_type)
+    assert_equal("V4HXmoUtMjohnsnow=KotN", apikey)
+    assert_equal("https://iamhost/iam/api=", iam_url)
+    assert_equal("https://gateway.watsonplatform.net/testService", service_url)
+
+    ENV.delete("VCAP_SERVICES")
+  end
 end


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1759

Changes:
- allow for a env config property's value to contain the ``=`` character
- add unit test cases