### PR TITLE
fix: update http gem dependency to 4.4.1

### DIFF
--- a/ibm_cloud_sdk_core.gemspec
+++ b/ibm_cloud_sdk_core.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 4.1.0"
+  spec.add_runtime_dependency "http", "~> 4.4.0"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/test/unit/test_base_service.rb
+++ b/test/unit/test_base_service.rb
@@ -113,7 +113,7 @@ class BaseServiceTest < Minitest::Test
         headers: {
           "Connection" => "close",
           "Host" => "iam.cloud.ibm.com",
-          "User-Agent" => "http.rb/4.1.1"
+          "User-Agent" => "http.rb/4.4.1"
         }
       )
       .to_return(status: 200, body: response.to_json, headers: {})

--- a/test/unit/test_cp4d_authenticator.rb
+++ b/test/unit/test_cp4d_authenticator.rb
@@ -37,7 +37,7 @@ class Cp4dAuthenticatorTest < Minitest::Test
           "Authorization" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
           "Connection" => "close",
           "Host" => "icp.com",
-          "User-Agent" => "http.rb/4.1.1"
+          "User-Agent" => "http.rb/4.4.1"
         }
       )
       .to_return(status: 200, body: response.to_json, headers: {})
@@ -77,7 +77,7 @@ class Cp4dAuthenticatorTest < Minitest::Test
           "Authorization" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
           "Connection" => "close",
           "Host" => "icp.com",
-          "User-Agent" => "http.rb/4.1.1"
+          "User-Agent" => "http.rb/4.4.1"
         }
       )
       .to_return(status: 200, body: response.to_json, headers: {})

--- a/test/unit/test_iam_authenticator.rb
+++ b/test/unit/test_iam_authenticator.rb
@@ -41,7 +41,7 @@ class IamAuthenticatorTest < Minitest::Test
         headers: {
           "Connection" => "close",
           "Host" => "iam.cloud.ibm.com",
-          "User-Agent" => "http.rb/4.1.1"
+          "User-Agent" => "http.rb/4.4.1"
         }
       )
       .to_return(status: 200, body: response.to_json, headers: {})
@@ -83,7 +83,7 @@ class IamAuthenticatorTest < Minitest::Test
           "Connection" => "close",
           "Authorization" => "Basic Yng6Yng=",
           "Host" => "iam.cloud.ibm.com",
-          "User-Agent" => "http.rb/4.1.1"
+          "User-Agent" => "http.rb/4.4.1"
         }
       )
       .to_return(status: 200, body: response.to_json, headers: {})
@@ -126,7 +126,7 @@ class IamAuthenticatorTest < Minitest::Test
         headers: {
           "Connection" => "close",
           "Host" => "iam.cloud.ibm.com",
-          "User-Agent" => "http.rb/4.1.1"
+          "User-Agent" => "http.rb/4.4.1"
         }
       )
       .to_return(status: 200, body: response.to_json, headers: {})
@@ -173,7 +173,7 @@ class IamAuthenticatorTest < Minitest::Test
         headers: {
           "Connection" => "close",
           "Host" => "my.link",
-          "User-Agent" => "http.rb/4.1.1"
+          "User-Agent" => "http.rb/4.4.1"
         }
       )
       .to_return(status: 200, body: response.to_json, headers: {})

--- a/test/unit/test_jwt_token_manager.rb
+++ b/test/unit/test_jwt_token_manager.rb
@@ -114,7 +114,7 @@ class JWTTokenManagerTest < Minitest::Test
           "Authorization" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
           "Connection" => "close",
           "Host" => "icp.com",
-          "User-Agent" => "http.rb/4.1.1"
+          "User-Agent" => "http.rb/4.4.1"
         }
       )
       .to_return(status: 200, body: response.to_json, headers: {})


### PR DESCRIPTION
Hi there,

I was integrating with the [Ruby SDK](https://github.com/watson-developer-cloud/ruby-sdk) in a rails app, which runs ruby 2.7.2. I wasn't able to initialize an `IamAuthenticator` object in that lib and traced it down to the http gem. Relevant stack trace portion:
```
[5] pry(#<Api::V1::AnalysesController>)> exception.backtrace
=> ["/Users/moses/development/foo/vendor/bundle/ruby/2.7.0/gems/http-4.1.1/lib/http/response/body.rb:52:in `force_encoding'",
 "/Users/moses/development/foo/vendor/bundle/ruby/2.7.0/gems/http-4.1.1/lib/http/response/body.rb:52:in `to_s'",
 "/Users/moses/development/foo/vendor/bundle/ruby/2.7.0/gems/ibm_cloud_sdk_core-1.1.2/lib/ibm_cloud_sdk_core/token_managers/jwt_token_manager.rb:85:in `request'",
 "/Users/moses/development/foo/vendor/bundle/ruby/2.7.0/gems/ibm_cloud_sdk_core-1.1.2/lib/ibm_cloud_sdk_core/token_managers/iam_token_manager.rb:54:in `request_token'",
 "/Users/moses/development/foo/vendor/bundle/ruby/2.7.0/gems/ibm_cloud_sdk_core-1.1.2/lib/ibm_cloud_sdk_core/token_managers/jwt_token_manager.rb:30:in `token'",
 "/Users/moses/development/foo/vendor/bundle/ruby/2.7.0/gems/ibm_cloud_sdk_core-1.1.2/lib/ibm_cloud_sdk_core/token_managers/iam_token_manager.rb:33:in `initialize'",
 "/Users/moses/development/foo/vendor/bundle/ruby/2.7.0/gems/ibm_cloud_sdk_core-1.1.2/lib/ibm_cloud_sdk_core/authenticators/iam_authenticator.rb:28:in `new'",
 "/Users/moses/development/foo/vendor/bundle/ruby/2.7.0/gems/ibm_cloud_sdk_core-1.1.2/lib/ibm_cloud_sdk_core/authenticators/iam_authenticator.rb:28:in `initialize'",
```

I came across this [fix](https://github.com/httprb/http/pull/581) that references the frozen string error. It was backported to http gem version 4.3.0. I updated the dependency in [Ruby SDK](https://github.com/watson-developer-cloud/ruby-sdk) but there too but it conflicted with the dependency in this project so I updated this one as well. After this fix (and the one in that repo, PR incoming) the code ran fine in rails on ruby 2.7.2 I'm running the project from gem sources in github at the moment, but here's a PR in case you want to update officially. This PR changes the dep to 4.4.x, but 4.1 -> 4.4 should be backwards-compatible. I'm not an expert at minitest but it seems all the tests pass with these changes (at least the ones triggered by `bundle exec rake`. 

Cheers