### PR TITLE
(Issue 36) fix IAM token timeout

### DIFF
--- a/lib/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.rb
+++ b/lib/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.rb
@@ -34,7 +34,7 @@ module IBMCloudSdkCore
 
     # Adds the Authorization header, if possible
     def authenticate(headers)
-      headers["Authorization"] = "Bearer #{@token_manager.access_token}"
+      headers["Authorization"] = "Bearer #{@token_manager.token}"
     end
 
     # Checks if all the inputs needed are present

--- a/lib/ibm_cloud_sdk_core/authenticators/iam_authenticator.rb
+++ b/lib/ibm_cloud_sdk_core/authenticators/iam_authenticator.rb
@@ -35,7 +35,7 @@ module IBMCloudSdkCore
     end
 
     def authenticate(headers)
-      headers["Authorization"] = "Bearer #{@token_manager.access_token}"
+      headers["Authorization"] = "Bearer #{@token_manager.token}"
     end
 
     def validate

--- a/test/unit/test_iam_token_manager.rb
+++ b/test/unit/test_iam_token_manager.rb
@@ -16,8 +16,8 @@ class IAMTokenManagerTest < Minitest::Test
       "iss": "sss",
       "aud": "sss",
       "uid": "sss",
-      "iat": Time.now.to_i + 3600,
-      "exp": Time.now.to_i
+      "iat": Time.now.to_i,
+      "exp": Time.now.to_i + 3600
     }
     token = JWT.encode token_layout, "secret", "HS256"
     response = {
@@ -108,8 +108,8 @@ class IAMTokenManagerTest < Minitest::Test
       "iss" => "sss",
       "aud" => "sss",
       "uid" => "sss",
-      "iat" => 3600,
-      "exp" => Time.now.to_i
+      "iat" => Time.now.to_i,
+      "exp" => Time.now.to_i + 3600
     }
 
     access_token = JWT.encode(access_token_layout, "secret", "HS256", "kid": "230498151c214b788dd97f22b85410a5")


### PR DESCRIPTION
### Use token method to manage timeout

The access_token reader doesn't manage the token, just takes the existing token (which can expire). Use the token method as defined on parent class JwtTokenManager which accesses the same information but also renews the token if it is expired or requests a new token if not present.

This patch is in regards to https://github.com/IBM/ruby-sdk-core/issues/36