### PR TITLE
fix: update http gem dependency to 5.1.1

### DIFF
--- a/ibm_cloud_sdk_core.gemspec
+++ b/ibm_cloud_sdk_core.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 4.4.0"
+  spec.add_runtime_dependency "http", "~> 5.1.1"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Fix `[HTTP::ConnectionError]: error reading from socket: Could not parse data` issues with `http-4.4.1`

Ref: https://github.com/httprb/http/issues/649

NOTE http breaking changes documented here https://github.com/httprb/http/blob/main/CHANGES.md#500-2021-05-12