### PR TITLE
Loosen dependencies on http / jwt gems

### DIFF
--- a/ibm_cloud_sdk_core.gemspec
+++ b/ibm_cloud_sdk_core.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 5.1.1"
-  spec.add_runtime_dependency "jwt", "~> 2.2.1"
+  spec.add_runtime_dependency "http", "~> 5.1"
+  spec.add_runtime_dependency "jwt", "~> 2.2"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "codecov", "~> 0.1"


### PR DESCRIPTION
Since this gem doesn't depend on anything in these specific versions we should allow the app that we are being included in to control the versions required.