### PR TITLE
Update jwt to 3.2.0 for CVE-2026-45363

### DIFF
--- a/ibm_cloud_sdk_core.gemspec
+++ b/ibm_cloud_sdk_core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "http", "~> 5.1"
-  spec.add_runtime_dependency "jwt", "~> 2.2"
+  spec.add_runtime_dependency "jwt", "~> 3.2"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "codecov", "~> 0.1"

--- a/lib/ibm_cloud_sdk_core/utils.rb
+++ b/lib/ibm_cloud_sdk_core/utils.rb
@@ -72,7 +72,7 @@ def load_from_vcap_services(service_name)
     services = JSON.parse(vcap_services)
     credentials = ""
     # search for matching inner name value
-    services.each do |_key, val|
+    services.each_value do |val|
       service = val.detect { |item| item["name"] == service_name }
       credentials = service["credentials"] unless service.nil?
       break unless credentials.nil? || credentials.empty?


### PR DESCRIPTION
Includes a rubocop fix that was preventing the tests from running.

@agrare Please review. I wasn't sure if there was more to test here outside of what the tests already cover

Note that the 3.0 upgrade instructions for the gem are here: https://github.com/jwt/ruby-jwt/blob/main/UPGRADING.md