### PR TITLE
Point codecov badge to the right branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/IBM/ruby-sdk-core/actions/workflows/ci.yaml/badge.svg)](https://github.com/IBM/ruby-sdk-core/actions/workflows/ci.yaml)
-[![codecov](https://codecov.io/gh/IBM/ruby-sdk-core/branch/main/graph/badge.svg)](https://codecov.io/gh/IBM/ruby-sdk-core)
+[![Codecov](https://codecov.io/gh/IBM/ruby-sdk-core/branch/main/graph/badge.svg)](https://codecov.io/gh/IBM/ruby-sdk-core/tree/main)
 [![Gem Version](https://badge.fury.io/rb/ibm_cloud_sdk_core.svg)](https://rubygems.org/gems/ibm_cloud_sdk_core)
 
 # ruby-sdk-core


### PR DESCRIPTION
This repo used to have a master branch, and because of that codecov's default landing page is the wrong branch. This updates the README to point directly to the main branch instead.

[skip ci]